### PR TITLE
fixed 1e100 error

### DIFF
--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -140,7 +140,7 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
             if neq > 0:
                 I_neq = I.repeat(neq, 1).t()
                 best['y'][I_neq] = y[I_neq]
-        if nNotImproved == notImprovedLim or best['resids'].max() < eps or mu.min() > 1e100:
+        if nNotImproved == notImprovedLim or best['resids'].max() < eps or mu.min() > 1e32:
             if best['resids'].max() > 1. and verbose >= 0:
                 print(INACC_ERR)
             return best['x'], best['y'], best['z'], best['s']

--- a/qpth/solvers/pdipm/spbatch.py
+++ b/qpth/solvers/pdipm/spbatch.py
@@ -111,7 +111,7 @@ def forward(Qi, Qv, Qsz, p, Gi, Gv, Gsz, h, Ai, Av, Asz, b,
             if neq > 0:
                 I_neq = I.repeat(neq, 1).t()
                 best['y'][I_neq] = y[I_neq]
-        if nNotImproved == notImprovedLim or best['resids'].max() < eps or mu.min() > 1e100:
+        if nNotImproved == notImprovedLim or best['resids'].max() < eps or mu.min() > 1e32:
             if best['resids'].max() > 1. and verbose >= 0:
                 print(INACC_ERR)
             return best['x'], best['y'], best['z'], best['s']


### PR DESCRIPTION
Got the following error a few times:

```value cannot be converted to type float without overflow: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.000000```

Changing 1e100 to 1e32 seemed to fix it. My guess is that ```mu.min()``` is a torch object that overrides ```>``` and throws an error when trying to convert 1e100 to float.