### PR TITLE
qpth breaks `conda env export` due to typo in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     url='https://github.com/locuslab/qpth',
     packages=find_packages(),
     install_requires=[
-        'numpy>=1<2',
+        'numpy>=1,<2',
     ]
 )


### PR DESCRIPTION
When installing qpth into a conda environment via pip, it's no longer possible to create a snapshot of the environment because conda's pip dependency parser fails on the qpth installation.

![image](https://user-images.githubusercontent.com/9562632/69486080-0efb3600-0e48-11ea-8181-9adc3362c585.png)


This PR fixes this by adding a simple comma.