### PR TITLE
Fix inf values for small/zero dv and improve dense batch performance

### DIFF
--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -582,7 +582,7 @@ def factor_kkt(S_LU, R, d):
             nBatch, 1, 1
         )
     T = R.clone()
-    T[factor_kkt_eye] += (1.0 / d).squeeze().view(-1)
+    T.diagonal(dim1=1, dim2=2).add_((1.0 / d).view(nBatch, nineq))
 
     T_LU = lu_hack(T)
 

--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -208,9 +208,15 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
 
 
 def get_step(v, dv):
-    a = -v / dv
-    a[dv > 0] = max(1.0, a.max())
-    return a.min(1)[0].squeeze()
+    n_batch = v.size(0)
+    step = torch.ones(n_batch, dtype=v.dtype, device=v.device)
+
+    mask = dv < 0
+    if mask.any():
+        a = torch.where(mask, -v / dv, torch.full_like(v, float("inf")))
+        step = a.min(1)[0].squeeze()
+
+    return step
 
 
 def unpack_kkt(v, nz, nineq, neq):

--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -1,14 +1,12 @@
 from enum import Enum
 
 import torch
-from line_profiler import profile
 
 from qpth.util import bdiag, get_sizes
 
 # from block import block
 
 
-@profile
 def lu_hack(x):
     data, pivots = torch.linalg.lu_factor(x, pivot=not x.is_cuda)
 
@@ -55,7 +53,6 @@ class KKTSolvers(Enum):
     IR_UNOPT = 3
 
 
-@profile
 def forward(
     Q,
     p,
@@ -272,13 +269,11 @@ def forward(
     return best["x"], best["y"], best["z"], best["s"]
 
 
-@profile
 def get_step(v, dv):
     a = torch.where(dv < 0, -v / dv, torch.full_like(v, float("inf")))
     return a.amin(dim=1)
 
 
-@profile
 def unpack_kkt(v, nz, nineq, neq):
     i = 0
     x = v[:, i : i + nz]
@@ -291,7 +286,6 @@ def unpack_kkt(v, nz, nineq, neq):
     return x, s, z, y
 
 
-@profile
 def kkt_resid_reg(Q_tilde, D_tilde, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry):
     dx, ds, dz, dy, rx, rs, rz, ry = [
         x.unsqueeze(2) if x is not None else None
@@ -309,7 +303,6 @@ def kkt_resid_reg(Q_tilde, D_tilde, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry):
     return resx, ress, resz, resy
 
 
-@profile
 def solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry, niter=1):
     """Inefficient iterative refinement."""
     nineq, nz, neq, nBatch = get_sizes(G, A)
@@ -350,7 +343,6 @@ def solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry, niter=1):
     return dx, ds, dz, dy
 
 
-@profile
 def factor_solve_kkt_reg(Q_tilde, D, G, A, rx, rs, rz, ry, eps):
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
@@ -427,7 +419,6 @@ def factor_solve_kkt_reg(Q_tilde, D, G, A, rx, rs, rz, ry, eps):
     return dx, ds, dz, dy
 
 
-@profile
 def factor_solve_kkt(Q, D, G, A, rx, rs, rz, ry):
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
@@ -483,7 +474,6 @@ def factor_solve_kkt(Q, D, G, A, rx, rs, rz, ry):
     return dx, ds, dz, dy
 
 
-@profile
 def solve_kkt(Q_LU, d, G, A, S_LU, rx, rs, rz, ry):
     """Solve KKT equations for the affine step"""
     nineq, nz, neq, nBatch = get_sizes(G, A)
@@ -515,7 +505,6 @@ def solve_kkt(Q_LU, d, G, A, S_LU, rx, rs, rz, ry):
     return dx, ds, dz, dy
 
 
-@profile
 def pre_factor_kkt(Q, G, A):
     """Perform all one-time factorizations and cache relevant matrix products"""
     nineq, nz, neq, nBatch = get_sizes(G, A)
@@ -581,7 +570,6 @@ a non-zero diagonal.
 factor_kkt_eye = None
 
 
-@profile
 def factor_kkt(S_LU, R, d):
     """Factor the U22 block that we can only do after we know D."""
     nBatch, nineq = d.size()

--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -1,20 +1,31 @@
-import torch
 from enum import Enum
+
+import torch
+from line_profiler import profile
+
+from qpth.util import bdiag, get_sizes
+
 # from block import block
 
-from qpth.util import get_sizes, bdiag
 
-
+@profile
 def lu_hack(x):
     data, pivots = torch.linalg.lu_factor(x, pivot=not x.is_cuda)
 
     if x.is_cuda:
         if x.ndimension() == 2:
-            pivots = torch.arange(1, 1+x.size(0)).int().to(x.device)
+            pivots = torch.arange(1, 1 + x.size(0), device=x.device).int()
         elif x.ndimension() == 3:
-            pivots = torch.arange(
-                1, 1+x.size(1),
-            ).unsqueeze(0).repeat(x.size(0), 1).int().to(x.device)
+            pivots = (
+                torch.arange(
+                    1,
+                    1 + x.size(1),
+                    device=x.device,
+                )
+                .unsqueeze(0)
+                .repeat(x.size(0), 1)
+                .int()
+            )
         else:
             assert False
     return (data, pivots)
@@ -44,8 +55,23 @@ class KKTSolvers(Enum):
     IR_UNOPT = 3
 
 
-def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLim=3,
-            maxIter=20, solver=KKTSolvers.LU_PARTIAL):
+@profile
+def forward(
+    Q,
+    p,
+    G,
+    h,
+    A,
+    b,
+    Q_LU,
+    S_LU,
+    R,
+    eps=1e-12,
+    verbose=0,
+    notImprovedLim=3,
+    maxIter=20,
+    solver=KKTSolvers.LU_PARTIAL,
+):
     """
     Q_LU, S_LU, R = pre_factor_kkt(Q, G, A)
     """
@@ -53,24 +79,43 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
 
     # Find initial values
     if solver == KKTSolvers.LU_FULL:
-        D = torch.eye(nineq).repeat(nBatch, 1, 1).type_as(Q)
+        D = torch.eye(nineq, device=Q.device, dtype=Q.dtype).repeat(nBatch, 1, 1)
         x, s, z, y = factor_solve_kkt(
-            Q, D, G, A, p,
-            torch.zeros(nBatch, nineq).type_as(Q),
-            -h, -b if b is not None else None)
+            Q,
+            D,
+            G,
+            A,
+            p,
+            torch.zeros(nBatch, nineq, device=Q.device, dtype=Q.dtype),
+            -h,
+            -b if b is not None else None,
+        )
     elif solver == KKTSolvers.LU_PARTIAL:
-        d = torch.ones(nBatch, nineq).type_as(Q)
+        d = torch.ones(nBatch, nineq, device=Q.device, dtype=Q.dtype)
         factor_kkt(S_LU, R, d)
         x, s, z, y = solve_kkt(
-            Q_LU, d, G, A, S_LU,
-            p, torch.zeros(nBatch, nineq).type_as(Q),
-            -h, -b if neq > 0 else None)
+            Q_LU,
+            d,
+            G,
+            A,
+            S_LU,
+            p,
+            torch.zeros(nBatch, nineq, device=Q.device, dtype=Q.dtype),
+            -h,
+            -b if neq > 0 else None,
+        )
     elif solver == KKTSolvers.IR_UNOPT:
-        D = torch.eye(nineq).repeat(nBatch, 1, 1).type_as(Q)
+        D = torch.eye(nineq, device=Q.device, dtype=Q.dtype).repeat(nBatch, 1, 1)
         x, s, z, y = solve_kkt_ir(
-            Q, D, G, A, p,
-            torch.zeros(nBatch, nineq).type_as(Q),
-            -h, -b if b is not None else None)
+            Q,
+            D,
+            G,
+            A,
+            p,
+            torch.zeros(nBatch, nineq, device=Q.device, dtype=Q.dtype),
+            -h,
+            -b if b is not None else None,
+        )
     else:
         assert False
 
@@ -86,19 +131,24 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
     I = M < 0
     z[I] -= M[I] - 1
 
-    best = {'resids': None, 'x': None, 'z': None, 's': None, 'y': None}
+    best = {"resids": None, "x": None, "z": None, "s": None, "y": None}
     nNotImproved = 0
 
     for i in range(maxIter):
         # affine scaling direction
-        rx = (torch.bmm(y.unsqueeze(1), A).squeeze(1) if neq > 0 else 0.) + \
-            torch.bmm(z.unsqueeze(1), G).squeeze(1) + \
-            torch.bmm(x.unsqueeze(1), Q.transpose(1, 2)).squeeze(1) + \
-            p
+        rx = (
+            (torch.bmm(y.unsqueeze(1), A).squeeze(1) if neq > 0 else 0.0)
+            + torch.bmm(z.unsqueeze(1), G).squeeze(1)
+            + torch.bmm(x.unsqueeze(1), Q.transpose(1, 2)).squeeze(1)
+            + p
+        )
         rs = z
         rz = torch.bmm(x.unsqueeze(1), G.transpose(1, 2)).squeeze(1) + s - h
-        ry = torch.bmm(x.unsqueeze(1), A.transpose(
-            1, 2)).squeeze(1) - b if neq > 0 else 0.0
+        ry = (
+            torch.bmm(x.unsqueeze(1), A.transpose(1, 2)).squeeze(1) - b
+            if neq > 0
+            else 0.0
+        )
         mu = torch.abs((s * z).sum(1).squeeze() / nineq)
         z_resid = torch.norm(rz, 2, 1).squeeze()
         y_resid = torch.norm(ry, 2, 1).squeeze() if neq > 0 else 0
@@ -110,79 +160,93 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
         try:
             factor_kkt(S_LU, R, d)
         except:
-            return best['x'], best['y'], best['z'], best['s']
+            return best["x"], best["y"], best["z"], best["s"]
 
         if verbose == 1:
-            print('iter: {}, pri_resid: {:.5e}, dual_resid: {:.5e}, mu: {:.5e}'.format(
-                i, pri_resid.mean(), dual_resid.mean(), mu.mean()))
-        if best['resids'] is None:
-            best['resids'] = resids
-            best['x'] = x.clone()
-            best['z'] = z.clone()
-            best['s'] = s.clone()
-            best['y'] = y.clone() if y is not None else None
+            print(
+                "iter: {}, pri_resid: {:.5e}, dual_resid: {:.5e}, mu: {:.5e}".format(
+                    i, pri_resid.mean(), dual_resid.mean(), mu.mean()
+                )
+            )
+        if best["resids"] is None:
+            best["resids"] = resids
+            best["x"] = x.clone()
+            best["z"] = z.clone()
+            best["s"] = s.clone()
+            best["y"] = y.clone() if y is not None else None
             nNotImproved = 0
         else:
-            I = resids < best['resids']
+            I = resids < best["resids"]
             if I.sum() > 0:
                 nNotImproved = 0
             else:
                 nNotImproved += 1
             I_nz = I.repeat(nz, 1).t()
             I_nineq = I.repeat(nineq, 1).t()
-            best['resids'][I] = resids[I]
-            best['x'][I_nz] = x[I_nz]
-            best['z'][I_nineq] = z[I_nineq]
-            best['s'][I_nineq] = s[I_nineq]
+            best["resids"][I] = resids[I]
+            best["x"][I_nz] = x[I_nz]
+            best["z"][I_nineq] = z[I_nineq]
+            best["s"][I_nineq] = s[I_nineq]
             if neq > 0:
                 I_neq = I.repeat(neq, 1).t()
-                best['y'][I_neq] = y[I_neq]
-        if nNotImproved == notImprovedLim or best['resids'].max() < eps or mu.min() > 1e32:
-            if best['resids'].max() > 1. and verbose >= 0:
+                best["y"][I_neq] = y[I_neq]
+        if (
+            nNotImproved == notImprovedLim
+            or best["resids"].max() < eps
+            or mu.min() > 1e32
+        ):
+            if best["resids"].max() > 1.0 and verbose >= 0:
                 print(INACC_ERR)
-            return best['x'], best['y'], best['z'], best['s']
+            return best["x"], best["y"], best["z"], best["s"]
 
         if solver == KKTSolvers.LU_FULL:
             D = bdiag(d)
             dx_aff, ds_aff, dz_aff, dy_aff = factor_solve_kkt(
-                Q, D, G, A, rx, rs, rz, ry)
+                Q, D, G, A, rx, rs, rz, ry
+            )
         elif solver == KKTSolvers.LU_PARTIAL:
             dx_aff, ds_aff, dz_aff, dy_aff = solve_kkt(
-                Q_LU, d, G, A, S_LU, rx, rs, rz, ry)
+                Q_LU, d, G, A, S_LU, rx, rs, rz, ry
+            )
         elif solver == KKTSolvers.IR_UNOPT:
             D = bdiag(d)
-            dx_aff, ds_aff, dz_aff, dy_aff = solve_kkt_ir(
-                Q, D, G, A, rx, rs, rz, ry)
+            dx_aff, ds_aff, dz_aff, dy_aff = solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry)
         else:
             assert False
 
         # compute centering directions
-        alpha = torch.min(torch.min(get_step(z, dz_aff),
-                                    get_step(s, ds_aff)),
-                          torch.ones(nBatch).type_as(Q))
+        alpha = torch.min(
+            torch.min(get_step(z, dz_aff), get_step(s, ds_aff)),
+            torch.ones(nBatch, device=Q.device, dtype=Q.dtype),
+        )
         alpha_nineq = alpha.repeat(nineq, 1).t()
         t1 = s + alpha_nineq * ds_aff
         t2 = z + alpha_nineq * dz_aff
         t3 = torch.sum(t1 * t2, 1).squeeze()
         t4 = torch.sum(s * z, 1).squeeze()
-        sig = (t3 / t4)**3
+        sig = (t3 / t4) ** 3
 
-        rx = torch.zeros(nBatch, nz).type_as(Q)
+        rx = torch.zeros(nBatch, nz, device=Q.device, dtype=Q.dtype)
         rs = ((-mu * sig).repeat(nineq, 1).t() + ds_aff * dz_aff) / s
-        rz = torch.zeros(nBatch, nineq).type_as(Q)
-        ry = torch.zeros(nBatch, neq).type_as(Q) if neq > 0 else torch.Tensor()
+        rz = torch.zeros(nBatch, nineq, device=Q.device, dtype=Q.dtype)
+        ry = (
+            torch.zeros(nBatch, neq, device=Q.device, dtype=Q.dtype)
+            if neq > 0
+            else torch.Tensor()
+        )
 
         if solver == KKTSolvers.LU_FULL:
             D = bdiag(d)
             dx_cor, ds_cor, dz_cor, dy_cor = factor_solve_kkt(
-                Q, D, G, A, rx, rs, rz, ry)
+                Q, D, G, A, rx, rs, rz, ry
+            )
         elif solver == KKTSolvers.LU_PARTIAL:
             dx_cor, ds_cor, dz_cor, dy_cor = solve_kkt(
-                Q_LU, d, G, A, S_LU, rx, rs, rz, ry)
+                Q_LU, d, G, A, S_LU, rx, rs, rz, ry
+            )
         elif solver == KKTSolvers.IR_UNOPT:
             D = bdiag(d)
-            dx_cor, ds_cor, dz_cor, dy_cor = solve_kkt_ir(
-                Q, D, G, A, rx, rs, rz, ry)
+            dx_cor, ds_cor, dz_cor, dy_cor = solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry)
         else:
             assert False
 
@@ -190,9 +254,10 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
         ds = ds_aff + ds_cor
         dz = dz_aff + dz_cor
         dy = dy_aff + dy_cor if neq > 0 else None
-        alpha = torch.min(0.999 * torch.min(get_step(z, dz),
-                                            get_step(s, ds)),
-                          torch.ones(nBatch).type_as(Q))
+        alpha = torch.min(
+            0.999 * torch.min(get_step(z, dz), get_step(s, ds)),
+            torch.ones(nBatch, device=Q.device, dtype=Q.dtype),
+        )
         alpha_nineq = alpha.repeat(nineq, 1).t()
         alpha_neq = alpha.repeat(neq, 1).t() if neq > 0 else None
         alpha_nz = alpha.repeat(nz, 1).t()
@@ -202,11 +267,12 @@ def forward(Q, p, G, h, A, b, Q_LU, S_LU, R, eps=1e-12, verbose=0, notImprovedLi
         z += alpha_nineq * dz
         y = y + alpha_neq * dy if neq > 0 else None
 
-    if best['resids'].max() > 1. and verbose >= 0:
+    if best["resids"].max() > 1.0 and verbose >= 0:
         print(INACC_ERR)
-    return best['x'], best['y'], best['z'], best['s']
+    return best["x"], best["y"], best["z"], best["s"]
 
 
+@profile
 def get_step(v, dv):
     n_batch = v.size(0)
     step = torch.ones(n_batch, dtype=v.dtype, device=v.device)
@@ -219,22 +285,24 @@ def get_step(v, dv):
     return step
 
 
+@profile
 def unpack_kkt(v, nz, nineq, neq):
     i = 0
-    x = v[:, i:i + nz]
+    x = v[:, i : i + nz]
     i += nz
-    s = v[:, i:i + nineq]
+    s = v[:, i : i + nineq]
     i += nineq
-    z = v[:, i:i + nineq]
+    z = v[:, i : i + nineq]
     i += nineq
-    y = v[:, i:i + neq]
+    y = v[:, i : i + neq]
     return x, s, z, y
 
 
+@profile
 def kkt_resid_reg(Q_tilde, D_tilde, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry):
     dx, ds, dz, dy, rx, rs, rz, ry = [
-        x.unsqueeze(2) if x is not None else None for x in
-        [dx, ds, dz, dy, rx, rs, rz, ry]
+        x.unsqueeze(2) if x is not None else None
+        for x in [dx, ds, dz, dy, rx, rs, rz, ry]
     ]
     resx = Q_tilde.bmm(dx) + G.transpose(1, 2).bmm(dz) + rx
     if dy is not None:
@@ -243,32 +311,45 @@ def kkt_resid_reg(Q_tilde, D_tilde, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry):
     resz = G.bmm(dx) + ds - eps * dz + rz
     resy = A.bmm(dx) - eps * dy + ry if dy is not None else None
     resx, ress, resz, resy = (
-        v.squeeze(2) if v is not None else None for v in (resx, ress, resz, resy))
+        v.squeeze(2) if v is not None else None for v in (resx, ress, resz, resy)
+    )
     return resx, ress, resz, resy
 
 
+@profile
 def solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry, niter=1):
     """Inefficient iterative refinement."""
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
     eps = 1e-7
-    Q_tilde = Q + eps * torch.eye(nz).type_as(Q).repeat(nBatch, 1, 1)
-    D_tilde = D + eps * torch.eye(nineq).type_as(Q).repeat(nBatch, 1, 1)
+    Q_tilde = Q + eps * torch.eye(nz, device=Q.device, dtype=Q.dtype).repeat(
+        nBatch, 1, 1
+    )
+    D_tilde = D + eps * torch.eye(nineq, device=Q.device, dtype=Q.dtype).repeat(
+        nBatch, 1, 1
+    )
 
-    dx, ds, dz, dy = factor_solve_kkt_reg(
-        Q_tilde, D_tilde, G, A, rx, rs, rz, ry, eps)
-    res = kkt_resid_reg(Q, D, G, A, eps,
-                        dx, ds, dz, dy, rx, rs, rz, ry)
+    dx, ds, dz, dy = factor_solve_kkt_reg(Q_tilde, D_tilde, G, A, rx, rs, rz, ry, eps)
+    res = kkt_resid_reg(Q, D, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry)
     resx, ress, resz, resy = res
     res = resx
     for k in range(niter):
-        ddx, dds, ddz, ddy = factor_solve_kkt_reg(Q_tilde, D_tilde, G, A, -resx, -ress, -resz,
-                                                  -resy if resy is not None else None,
-                                                  eps)
-        dx, ds, dz, dy = [v + dv if v is not None else None
-                          for v, dv in zip((dx, ds, dz, dy), (ddx, dds, ddz, ddy))]
-        res = kkt_resid_reg(Q, D, G, A, eps,
-                            dx, ds, dz, dy, rx, rs, rz, ry)
+        ddx, dds, ddz, ddy = factor_solve_kkt_reg(
+            Q_tilde,
+            D_tilde,
+            G,
+            A,
+            -resx,
+            -ress,
+            -resz,
+            -resy if resy is not None else None,
+            eps,
+        )
+        dx, ds, dz, dy = [
+            v + dv if v is not None else None
+            for v, dv in zip((dx, ds, dz, dy), (ddx, dds, ddz, ddy))
+        ]
+        res = kkt_resid_reg(Q, D, G, A, eps, dx, ds, dz, dy, rx, rs, rz, ry)
         resx, ress, resz, resy = res
         # res = torch.cat(resx)
         res = resx
@@ -276,22 +357,57 @@ def solve_kkt_ir(Q, D, G, A, rx, rs, rz, ry, niter=1):
     return dx, ds, dz, dy
 
 
+@profile
 def factor_solve_kkt_reg(Q_tilde, D, G, A, rx, rs, rz, ry, eps):
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
-    H_ = torch.zeros(nBatch, nz + nineq, nz + nineq).type_as(Q_tilde)
+    H_ = torch.zeros(
+        nBatch, nz + nineq, nz + nineq, device=Q_tilde.device, dtype=Q_tilde.dtype
+    )
     H_[:, :nz, :nz] = Q_tilde
     H_[:, -nineq:, -nineq:] = D
     if neq > 0:
         # H_ = torch.cat([torch.cat([Q, torch.zeros(nz,nineq).type_as(Q)], 1),
         # torch.cat([torch.zeros(nineq, nz).type_as(Q), D], 1)], 0)
-        A_ = torch.cat([torch.cat([G, torch.eye(nineq).type_as(Q_tilde).repeat(nBatch, 1, 1)], 2),
-                        torch.cat([A, torch.zeros(nBatch, neq, nineq).type_as(Q_tilde)], 2)], 1)
+        A_ = torch.cat(
+            [
+                torch.cat(
+                    [
+                        G,
+                        torch.eye(
+                            nineq, device=Q_tilde.device, dtype=Q_tilde.dtype
+                        ).repeat(nBatch, 1, 1),
+                    ],
+                    2,
+                ),
+                torch.cat(
+                    [
+                        A,
+                        torch.zeros(
+                            nBatch,
+                            neq,
+                            nineq,
+                            device=Q_tilde.device,
+                            dtype=Q_tilde.dtype,
+                        ),
+                    ],
+                    2,
+                ),
+            ],
+            1,
+        )
         g_ = torch.cat([rx, rs], 1)
         h_ = torch.cat([rz, ry], 1)
     else:
         A_ = torch.cat(
-            [G, torch.eye(nineq).type_as(Q_tilde).repeat(nBatch, 1, 1)], 2)
+            [
+                G,
+                torch.eye(nineq, device=Q_tilde.device, dtype=Q_tilde.dtype).repeat(
+                    nBatch, 1, 1
+                ),
+            ],
+            2,
+        )
         g_ = torch.cat([rx, rs], 1)
         h_ = rz
 
@@ -301,7 +417,9 @@ def factor_solve_kkt_reg(Q_tilde, D, G, A, rx, rs, rz, ry, eps):
     invH_g_ = torch.linalg.lu_solve(*H_LU, g_.unsqueeze(2)).squeeze(2)
 
     S_ = torch.bmm(A_, invH_A_)
-    S_ -= eps * torch.eye(neq + nineq).type_as(Q_tilde).repeat(nBatch, 1, 1)
+    S_ -= eps * torch.eye(
+        neq + nineq, device=Q_tilde.device, dtype=Q_tilde.dtype
+    ).repeat(nBatch, 1, 1)
     S_LU = lu_hack(S_)
     t_ = torch.bmm(invH_g_.unsqueeze(1), A_.transpose(1, 2)).squeeze(1) - h_
     w_ = torch.linalg.lu_solve(*S_LU, -t_.unsqueeze(2)).squeeze(2)
@@ -316,19 +434,39 @@ def factor_solve_kkt_reg(Q_tilde, D, G, A, rx, rs, rz, ry, eps):
     return dx, ds, dz, dy
 
 
+@profile
 def factor_solve_kkt(Q, D, G, A, rx, rs, rz, ry):
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
-    H_ = torch.zeros(nBatch, nz + nineq, nz + nineq).type_as(Q)
+    H_ = torch.zeros(nBatch, nz + nineq, nz + nineq, device=Q.device, dtype=Q.dtype)
     H_[:, :nz, :nz] = Q
     H_[:, -nineq:, -nineq:] = D
     if neq > 0:
-        A_ = torch.cat([torch.cat([G, torch.eye(nineq).type_as(Q).repeat(nBatch, 1, 1)], 2),
-                        torch.cat([A, torch.zeros(nBatch, neq, nineq).type_as(Q)], 2)], 1)
+        A_ = torch.cat(
+            [
+                torch.cat(
+                    [
+                        G,
+                        torch.eye(nineq, device=Q.device, dtype=Q.dtype).repeat(
+                            nBatch, 1, 1
+                        ),
+                    ],
+                    2,
+                ),
+                torch.cat(
+                    [
+                        A,
+                        torch.zeros(nBatch, neq, nineq, device=Q.device, dtype=Q.dtype),
+                    ],
+                    2,
+                ),
+            ],
+            1,
+        )
         g_ = torch.cat([rx, rs], 1)
         h_ = torch.cat([rz, ry], 1)
     else:
-        A_ = torch.cat([G, torch.eye(nineq).type_as(Q)], 1)
+        A_ = torch.cat([G, torch.eye(nineq, device=Q.device, dtype=Q.dtype)], 1)
         g_ = torch.cat([rx, rs], 1)
         h_ = rz
 
@@ -352,14 +490,20 @@ def factor_solve_kkt(Q, D, G, A, rx, rs, rz, ry):
     return dx, ds, dz, dy
 
 
+@profile
 def solve_kkt(Q_LU, d, G, A, S_LU, rx, rs, rz, ry):
-    """ Solve KKT equations for the affine step"""
+    """Solve KKT equations for the affine step"""
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
     invQ_rx = torch.linalg.lu_solve(*Q_LU, rx.unsqueeze(2)).squeeze(2)
     if neq > 0:
-        h = torch.cat((invQ_rx.unsqueeze(1).bmm(A.transpose(1, 2)).squeeze(1) - ry,
-                       invQ_rx.unsqueeze(1).bmm(G.transpose(1, 2)).squeeze(1) + rs / d - rz), 1)
+        h = torch.cat(
+            (
+                invQ_rx.unsqueeze(1).bmm(A.transpose(1, 2)).squeeze(1) - ry,
+                invQ_rx.unsqueeze(1).bmm(G.transpose(1, 2)).squeeze(1) + rs / d - rz,
+            ),
+            1,
+        )
     else:
         h = invQ_rx.unsqueeze(1).bmm(G.transpose(1, 2)).squeeze(1) + rs / d - rz
 
@@ -378,18 +522,21 @@ def solve_kkt(Q_LU, d, G, A, S_LU, rx, rs, rz, ry):
     return dx, ds, dz, dy
 
 
+@profile
 def pre_factor_kkt(Q, G, A):
-    """ Perform all one-time factorizations and cache relevant matrix products"""
+    """Perform all one-time factorizations and cache relevant matrix products"""
     nineq, nz, neq, nBatch = get_sizes(G, A)
 
     try:
         Q_LU = lu_hack(Q)
     except:
-        raise RuntimeError("""
+        raise RuntimeError(
+            """
 qpth Error: Cannot perform LU factorization on Q.
 Please make sure that your Q matrix is PSD and has
 a non-zero diagonal.
-""")
+"""
+        )
 
     # S = [ A Q^{-1} A^T        A Q^{-1} G^T          ]
     #     [ G Q^{-1} A^T        G Q^{-1} G^T + D^{-1} ]
@@ -399,12 +546,13 @@ a non-zero diagonal.
     # See the 'Block LU factorization' part of our website
     # for more details.
 
-    G_invQ_GT = torch.bmm(
-        G,
-        torch.linalg.lu_solve(*Q_LU, G.transpose(1, 2)))
+    G_invQ_GT = torch.bmm(G, torch.linalg.lu_solve(*Q_LU, G.transpose(1, 2)))
     R = G_invQ_GT.clone()
-    S_LU_pivots = torch.IntTensor(range(1, 1 + neq + nineq)).unsqueeze(0) \
-        .repeat(nBatch, 1).type_as(Q).int()
+    S_LU_pivots = (
+        torch.arange(1, 1 + neq + nineq, device=Q.device, dtype=torch.int32)
+        .unsqueeze(0)
+        .repeat(nBatch, 1)
+    )
     if neq > 0:
         invQ_AT = torch.linalg.lu_solve(*Q_LU, A.transpose(1, 2))
         A_invQ_AT = torch.bmm(A, invQ_AT)
@@ -412,24 +560,26 @@ a non-zero diagonal.
 
         LU_A_invQ_AT = lu_hack(A_invQ_AT)
         P_A_invQ_AT, L_A_invQ_AT, U_A_invQ_AT = torch.lu_unpack(*LU_A_invQ_AT)
-        P_A_invQ_AT = P_A_invQ_AT.type_as(A_invQ_AT)
+        P_A_invQ_AT = torch.as_tensor(
+            P_A_invQ_AT, device=A_invQ_AT.device, dtype=A_invQ_AT.dtype
+        )
 
         S_LU_11 = LU_A_invQ_AT[0]
         U_A_invQ_AT_inv = torch.linalg.lu_solve(
-            *LU_A_invQ_AT, P_A_invQ_AT.bmm(L_A_invQ_AT))
+            *LU_A_invQ_AT, P_A_invQ_AT.bmm(L_A_invQ_AT)
+        )
         S_LU_21 = G_invQ_AT.bmm(U_A_invQ_AT_inv)
-        T = torch.linalg.lu_solve(
-            *LU_A_invQ_AT, G_invQ_AT.transpose(1, 2))
+        T = torch.linalg.lu_solve(*LU_A_invQ_AT, G_invQ_AT.transpose(1, 2))
         S_LU_12 = U_A_invQ_AT.bmm(T)
-        S_LU_22 = torch.zeros(nBatch, nineq, nineq).type_as(Q)
-        S_LU_data = torch.cat((torch.cat((S_LU_11, S_LU_12), 2),
-                               torch.cat((S_LU_21, S_LU_22), 2)),
-                              1)
+        S_LU_22 = torch.zeros(nBatch, nineq, nineq, device=Q.device, dtype=Q.dtype)
+        S_LU_data = torch.cat(
+            (torch.cat((S_LU_11, S_LU_12), 2), torch.cat((S_LU_21, S_LU_22), 2)), 1
+        )
         S_LU_pivots[:, :neq] = LU_A_invQ_AT[1]
 
         R -= G_invQ_AT.bmm(T)
     else:
-        S_LU_data = torch.zeros(nBatch, nineq, nineq).type_as(Q)
+        S_LU_data = torch.zeros(nBatch, nineq, nineq, device=Q.device, dtype=Q.dtype)
 
     S_LU = [S_LU_data, S_LU_pivots]
     return Q_LU, S_LU, R
@@ -438,18 +588,20 @@ a non-zero diagonal.
 factor_kkt_eye = None
 
 
+@profile
 def factor_kkt(S_LU, R, d):
-    """ Factor the U22 block that we can only do after we know D. """
+    """Factor the U22 block that we can only do after we know D."""
     nBatch, nineq = d.size()
     neq = S_LU[1].size(1) - nineq
     # TODO: There's probably a better way to add a batched diagonal.
     global factor_kkt_eye
     if factor_kkt_eye is None or factor_kkt_eye.size() != d.size():
         # print('Updating batchedEye size.')
-        factor_kkt_eye = torch.eye(nineq).repeat(
-            nBatch, 1, 1).type_as(R).bool()
+        factor_kkt_eye = torch.eye(nineq, device=R.device, dtype=torch.bool).repeat(
+            nBatch, 1, 1
+        )
     T = R.clone()
-    T[factor_kkt_eye] += (1. / d).squeeze().view(-1)
+    T[factor_kkt_eye] += (1.0 / d).squeeze().view(-1)
 
     T_LU = lu_hack(T)
 
@@ -457,17 +609,16 @@ def factor_kkt(S_LU, R, d):
         # TODO: Don't use pivoting in most cases because
         # torch.lu_unpack is inefficient here:
         oldPivotsPacked = S_LU[1][:, -nineq:] - neq
-        oldPivots, _, _ = torch.lu_unpack(
-            T_LU[0], oldPivotsPacked, unpack_data=False)
+        oldPivots, _, _ = torch.lu_unpack(T_LU[0], oldPivotsPacked, unpack_data=False)
         newPivotsPacked = T_LU[1]
-        newPivots, _, _ = torch.lu_unpack(
-            T_LU[0], newPivotsPacked, unpack_data=False)
+        newPivots, _, _ = torch.lu_unpack(T_LU[0], newPivotsPacked, unpack_data=False)
 
         # Re-pivot the S_LU_21 block.
         if neq > 0:
             S_LU_21 = S_LU[0][:, -nineq:, :neq]
-            S_LU[0][:, -nineq:,
-                    :neq] = newPivots.transpose(1, 2).bmm(oldPivots.bmm(S_LU_21))
+            S_LU[0][:, -nineq:, :neq] = newPivots.transpose(1, 2).bmm(
+                oldPivots.bmm(S_LU_21)
+            )
 
         # Add the new S_LU_22 block pivots.
         S_LU[1][:, -nineq:] = newPivotsPacked + neq

--- a/qpth/solvers/pdipm/batch.py
+++ b/qpth/solvers/pdipm/batch.py
@@ -274,15 +274,8 @@ def forward(
 
 @profile
 def get_step(v, dv):
-    n_batch = v.size(0)
-    step = torch.ones(n_batch, dtype=v.dtype, device=v.device)
-
-    mask = dv < 0
-    if mask.any():
-        a = torch.where(mask, -v / dv, torch.full_like(v, float("inf")))
-        step = a.min(1)[0].squeeze()
-
-    return step
+    a = torch.where(dv < 0, -v / dv, torch.full_like(v, float("inf")))
+    return a.amin(dim=1)
 
 
 @profile


### PR DESCRIPTION
Get_step will produce inf values, which causes nans when dv is small/zero. This fixes the issue.

I also improved performance by constructing objects directly on the target device as opposed to utilising `to` or `type_as`.
